### PR TITLE
add failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.1.1
+- pinned sinon dependency to `6.1.2`, stubApp method is broken on higher versions
+
 ## v1.1.0
 - upgraded most of the dependencies
 - added `reset` method to clean the stub and internal db states

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-application",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Microservice stubs using Express, Sinon and Event Emitter",
   "main": "src/mini-application.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "lodash": "^4.17.10",
     "lowdb": "^1.0.0",
     "shelljs": "^0.8.2",
-    "sinon": "^6.1.0",
+    "sinon": "6.1.2",
     "superagent": "^3.8.3"
   },
   "optionalDependencies": {

--- a/test/stub-response-test.js
+++ b/test/stub-response-test.js
@@ -77,5 +77,20 @@ describe("Mini Application Stub", () => {
       });
   });
 
+
+  it("should not mix responses", () => {
+    miniApp.stubApp("/test").respond("test");
+    miniApp.stubApp("/foo").respond("foo");
+    return Promise.all([
+      request
+        .get("http://localhost:3000/test")
+        .then((res) => expect(res.text).to.equal("test")),
+      request
+        .get("http://localhost:3000/foo")
+        .then((res) => expect(res.text).to.equal("foo"))
+    ]);
+  });
+
+
   afterEach(() => miniApp.close());
 });


### PR DESCRIPTION
See code for a failing test that breaks tests for `hull-mailchimp` in https://github.com/hull-ships/hull-mailchimp/blob/develop/test/integration/sync-test.js#L70:

Connector tries to fetch `/api/v1/123456789012345678901234` (Connector configuration),
gets response from Line 70: "ok"